### PR TITLE
docs(rust): add crate metadata and README for aiir-cbor-verify

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -6,7 +6,13 @@ name = "aiir-cbor-verify"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "Cross-language deterministic CBOR decoder for AIIR canonical objects"
+description = "Cross-language deterministic CBOR decoder and verifier for AIIR commit receipts"
+repository = "https://github.com/invariant-systems-ai/aiir"
+homepage = "https://invariantsystems.io/spec"
+documentation = "https://invariantsystems.io/conformance"
+readme = "README.md"
+keywords = ["aiir", "cbor", "verification", "provenance", "integrity"]
+categories = ["cryptography", "encoding", "development-tools"]
 
 [dependencies]
 sha2 = "0.10"

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -1,0 +1,42 @@
+# aiir-cbor-verify
+
+Deterministic CBOR encoder, decoder, and verifier for
+[AIIR](https://github.com/invariant-systems-ai/aiir) commit receipts.
+
+## What it does
+
+- **Decodes** CBOR with strict validation — rejects non-canonical forms
+- **Verifies** CBOR sidecars by round-tripping through canonical JSON and checking SHA-256
+- Proves **cross-language determinism**: the same receipt produces the same
+  `content_hash` whether processed by the Python reference implementation or this
+  Rust crate
+
+## Canonicalization rules
+
+| Rule | Detail |
+|------|--------|
+| Shortest integer encoding | Integers use the smallest CBOR head (1/2/4/8 bytes) |
+| No indefinite-length | All containers use definite length |
+| Deterministic map key order | Sorted by (encoded-length, lexicographic-bytes) |
+| No non-finite floats | NaN, ±Inf rejected |
+
+See [RFC 8949 §4.2](https://www.rfc-editor.org/rfc/rfc8949#section-4.2) and the
+[AIIR SPEC](https://github.com/invariant-systems-ai/aiir/blob/main/SPEC.md) for details.
+
+## Usage
+
+```toml
+[dependencies]
+aiir-cbor-verify = "0.1"
+```
+
+```rust
+use aiir_cbor_verify::{decode, CborValue};
+
+let cbor_bytes: &[u8] = &[/* CBOR-encoded receipt */];
+let value: CborValue = decode(cbor_bytes)?;
+```
+
+## License
+
+Apache-2.0 — see [LICENSE](../../LICENSE).


### PR DESCRIPTION
## Summary

Adds proper crate metadata and a README for the `aiir-cbor-verify` Rust SDK crate to prepare for eventual crates.io publication.

## Changes

### `sdks/rust/Cargo.toml`
- Updated description to reflect verification capability
- Added `repository`, `homepage`, `documentation` URLs
- Added `readme`, `keywords`, `categories` fields

### `sdks/rust/README.md` (new)
- Describes what the crate does (decode, verify, cross-language determinism)
- Documents canonicalization rules (shortest encoding, no indefinite-length, key sort order, no NaN/Inf)
- Provides usage example
- Links to RFC 8949 §4.2 and AIIR SPEC