### PR TITLE
feat(dogfood): commit CBOR sidecars + explain cross-verification

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -45,9 +45,13 @@ jobs:
 
       # ── Verify every receipt we just generated ──
       # This is the dogfood proof: AIIR validates its own output.
+      # --verify auto-detects .cbor sidecars next to each .json file
+      # and cross-verifies them (round-trip + digest match).
       - name: Verify receipt integrity
         run: |
           FAIL=0
+          CBOR_OK=0
+          CBOR_FAIL=0
           for receipt in .receipts/*.json; do
             [ -f "$receipt" ] || continue
             # Skip .sigstore bundles (not receipt JSON)
@@ -58,12 +62,21 @@ jobs:
               echo "  ❌ $(basename "$receipt")"
               FAIL=1
             fi
+            # Check that the CBOR sidecar was generated
+            cbor="${receipt%.json}.cbor"
+            if [ -f "$cbor" ]; then
+              CBOR_OK=$((CBOR_OK + 1))
+            else
+              echo "  ⚠️  Missing CBOR sidecar: $(basename "$cbor")"
+              CBOR_FAIL=$((CBOR_FAIL + 1))
+            fi
           done
           if [ "$FAIL" -eq 1 ]; then
             echo "::error::One or more receipts failed integrity verification"
             exit 1
           fi
           echo "✅ All receipts passed content-addressed integrity verification"
+          echo "✅ CBOR sidecars: ${CBOR_OK} verified, ${CBOR_FAIL} missing"
 
       # ── Chain integrity: no gaps in the receipts branch ──
       - name: Check receipt chain continuity
@@ -118,7 +131,7 @@ jobs:
 
           cd "$WORK"
           cp "${GITHUB_WORKSPACE}/.receipts/"* . 2>/dev/null || true
-          git add *.json *.sigstore 2>/dev/null || true
+          git add *.json *.cbor *.sigstore 2>/dev/null || true
 
           if ! git diff --cached --quiet; then
             git commit -m "chore: receipts for ${GITHUB_SHA::12}"

--- a/aiir/_explain.py
+++ b/aiir/_explain.py
@@ -170,4 +170,23 @@ def explain_verification(result: Dict[str, Any]) -> str:
         if len(schema_errors) > 10:
             lines.append(f"  ... and {len(schema_errors) - 10} more")
 
+    # CBOR sidecar cross-verification
+    cbor = result.get("cbor_sidecar")
+    if isinstance(cbor, dict):
+        lines.append("")
+        if cbor.get("valid"):
+            lines.append("CBOR sidecar: VERIFIED")
+            lines.append(
+                "  The canonical CBOR sidecar was decoded, re-encoded to"
+                " identical bytes (round-trip), and cross-verified against"
+                " the JSON receipt core."
+            )
+            if cbor.get("cbor_sha256"):
+                lines.append(f"  Digest: {cbor['cbor_sha256']}")
+        else:
+            cbor_errors = cbor.get("errors", [])
+            lines.append("CBOR sidecar: FAILED")
+            for ce in cbor_errors:
+                lines.append(f"  - {ce}")
+
     return "\n".join(lines)

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -121,6 +121,48 @@ class TestExplainVerification(unittest.TestCase):
         text = explain_verification(result)
         self.assertIn("... and 5 more", text)
 
+    def test_cbor_sidecar_verified(self):
+        result = {
+            "valid": True,
+            "cbor_sidecar": {
+                "valid": True,
+                "cbor_sha256": "sha256:abcdef1234567890",
+            },
+        }
+        text = explain_verification(result)
+        self.assertIn("CBOR sidecar: VERIFIED", text)
+        self.assertIn("round-trip", text)
+        self.assertIn("sha256:abcdef1234567890", text)
+
+    def test_cbor_sidecar_failed(self):
+        result = {
+            "valid": False,
+            "errors": ["content hash mismatch"],
+            "cbor_sidecar": {
+                "valid": False,
+                "errors": ["round-trip mismatch"],
+            },
+        }
+        text = explain_verification(result)
+        self.assertIn("CBOR sidecar: FAILED", text)
+        self.assertIn("round-trip mismatch", text)
+
+    def test_cbor_sidecar_verified_no_digest(self):
+        """CBOR valid but cbor_sha256 absent — should still say VERIFIED."""
+        result = {
+            "valid": True,
+            "cbor_sidecar": {"valid": True},
+        }
+        text = explain_verification(result)
+        self.assertIn("CBOR sidecar: VERIFIED", text)
+        self.assertNotIn("Digest:", text)
+
+    def test_cbor_sidecar_absent(self):
+        """No cbor_sidecar key — explain should not mention CBOR."""
+        result = {"valid": True}
+        text = explain_verification(result)
+        self.assertNotIn("CBOR", text)
+
 
 class TestExplainVerificationCLI(unittest.TestCase):
     """Test that --explain integrates with the CLI."""


### PR DESCRIPTION
## Summary

AIIR now fully dogfoods its own CBOR sidecar feature — the receipt proof goes all the way down.

### Changes

**dogfood.yml**
- Add `*.cbor` to the `git add` on the receipts branch, so CBOR sidecars are preserved alongside JSON receipts and Sigstore bundles
- Verify step checks each receipt has a companion `.cbor` sidecar and reports the count (`--verify --explain` already cross-verifies the CBOR against the JSON receipt automatically)

**_explain.py**
- `explain_verification()` surfaces CBOR sidecar results: **VERIFIED** with digest, or **FAILED** with specific error details

**Tests**
- 3 new tests: CBOR verified, CBOR failed, CBOR absent

### Why

Extra pudding proof: AIIR receipts its own commits, signs them with Sigstore, generates canonical CBOR sidecars, cross-verifies the CBOR against JSON, and commits all three formats to the `receipts` branch. The dogfood loop is now complete for the full receipt envelope.